### PR TITLE
Fixed issue which was caused by missed early return

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -27,12 +27,13 @@ class App extends React.Component {
     setAutocompleteOptions = async (inputValue) => {
         if (!inputValue) {
             this.setState({options: []});
+            return
         }
 
         const options = await retrieveOptions(inputValue);
 
         // The input value had been changed since the request was created
-        if (this.state.inputValue !== inputValue || inputValue === '') {
+        if (this.state.inputValue !== inputValue) {
             return
         }
 


### PR DESCRIPTION
In this PR I've changed code flow a bit to be more optimal written. In the case when the input is empty it's not necessary to execute and other code or do any requests, we can just set options for autocomplete to be an empty array. We don't show the options for empty input in the current implementation.

The next code line that makes a comparison of previous and current input value still does the protection from request races. For any other request results even if they will be given later they will make the early return just because of the current input empty state which is not the input that was used to request the data. 

See how it works:
![demo](https://user-images.githubusercontent.com/5417461/141688494-5e5de321-53ce-46c7-a523-631306a46371.gif)

Note: this is not the real pull request, just created for this education video:

[![How to improve your code review process
](https://user-images.githubusercontent.com/5417461/141688414-4151b1ee-75bc-4246-afb2-1a38e28c9803.png)](https://youtu.be/t3lfY7p_Ris)
